### PR TITLE
Minor YAML-related cleanup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Update the cache with the Okta ASA goodness
   ansible.builtin.package:
-    update_cache: yes
+    update_cache: true
   # This cache update can cause idempotence to fail, so tell molecule
   # to ignore any changes this task produces when testing idempotence.
   tags:
@@ -25,5 +25,5 @@
 
 - name: Enable sftd
   ansible.builtin.service:
-    enabled: yes
+    enabled: true
     name: sftd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,5 +25,5 @@
 
 - name: Enable sftd
   ansible.builtin.service:
-    name: sftd
     enabled: yes
+    name: sftd


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does two minor things:
- Ensure map keys are sorted alphabetically within the confines of `ansible-lint`'s preferences.
- Prefer the use of `true`/`false` to `yes`/`no` for boolean values.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These are both best practices for our team. The latter we are not currently enforcing with the `yamllint` configuration because it conflicts with `ansible-lint` defaults per [this Ansible documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#boolean-variables).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
